### PR TITLE
DR-780 Fix dr tree command when no files

### DIFF
--- a/src/main/java/bio/terra/model/DRCollectionFiles.java
+++ b/src/main/java/bio/terra/model/DRCollectionFiles.java
@@ -3,11 +3,17 @@ package bio.terra.model;
 import bio.terra.command.CommandUtils;
 import bio.terra.command.DRApis;
 import bio.terra.datarepo.client.ApiException;
+import bio.terra.datarepo.model.DirectoryDetailModel;
 import bio.terra.datarepo.model.FileModel;
+import bio.terra.datarepo.model.FileModelType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import static bio.terra.model.DRCollectionType.COLLECTION_TYPE_DATASET;
 
@@ -85,6 +91,20 @@ public class DRCollectionFiles extends DRElement {
         try {
             return pathLookup("/", 1);
         } catch (ApiException ex) {
+            try {
+                // if there are no files or directories in this collection AND it is the top-level files collection,
+                // then create an empty directory object here and mark it as already enumerated instead of exiting
+                // the process with the file not found exception from the API
+                Map<String, String> errorMap = CommandUtils.getObjectMapper()
+                        .readValue(ex.getMessage(), new TypeReference<Map<String, String>>() {});
+                if (StringUtils.containsIgnoreCase(errorMap.get("message"), "File not found:")) {
+                    DirectoryDetailModel directoryDetail = new DirectoryDetailModel()
+                            .contents(new ArrayList<FileModel>()).enumerated(true);
+                    return new FileModel().fileType(FileModelType.DIRECTORY).directoryDetail(directoryDetail);
+                }
+            } catch (JsonProcessingException jsonEx) {
+                // error parsing as json, just ignore and fall through to the process exit
+            }
             CommandUtils.printErrorAndExit("Error getting root file object");
         }
         return null; // unreachable

--- a/src/main/java/bio/terra/model/DRCollectionFiles.java
+++ b/src/main/java/bio/terra/model/DRCollectionFiles.java
@@ -100,7 +100,7 @@ public class DRCollectionFiles extends DRElement {
                 try {
                     // parse the response body to build a JSON object
                     Map<String, String> errorMap = CommandUtils.getObjectMapper()
-                            .readValue(ex.getMessage(), new TypeReference<Map<String, String>>() {});
+                            .readValue(ex.getResponseBody(), new TypeReference<Map<String, String>>() {});
                     // then extract the message property and check it matches the not found case
                     if (StringUtils.containsIgnoreCase(errorMap.get("message"), "File not found:")) {
 


### PR DESCRIPTION
Updated dr tree command to not error out when a snapshot or dataset contains no files. I catch the error and create an empty, already enumerated directory object instead.